### PR TITLE
Monkishprawn alpha zero

### DIFF
--- a/eph_beta.h
+++ b/eph_beta.h
@@ -175,7 +175,7 @@ class EPH_Beta {
       if(rho_i > rho_cutoff){
 
                 if(once){
-                        std::cout << 'WARNING: function get_beta() in$
+                        std::cout << 'WARNING: function get_beta() in eph_beta.h: rho_i > rho_cutoff, beta set to zero\n';
                         once = false;
                 }
 
@@ -193,7 +193,7 @@ class EPH_Beta {
       if(rho_i > rho_cutoff){
 
                 if(once){
-                        std::cout << 'WARNING: function get_alpha() i$
+                        std::cout << 'WARNING: function get_alpha() in eph_beta.h: rho_i > rho_cutoff, alpha set to zero\n';
                         once = false;
                 }
 

--- a/eph_beta.h
+++ b/eph_beta.h
@@ -170,14 +170,35 @@ class EPH_Beta {
 
     Float get_beta(size_t index, Float rho_i) const {
       assert(index < n_elements);
-      assert(rho_i < rho_cutoff);
+      static bool once = true;
+
+      if(rho_i > rho_cutoff){
+
+                if(once){
+                        std::cout << 'WARNING: function get_beta() in$
+                        once = false;
+                }
+
+                return 0;
+      }
+
 
       return beta[index](rho_i);
     }
 
     Float get_alpha(size_t index, Float rho_i) const {
       assert(index < n_elements);
-      assert(rho_i < rho_cutoff);
+      static bool once = true;
+
+      if(rho_i > rho_cutoff){
+
+                if(once){
+                        std::cout << 'WARNING: function get_alpha() i$
+                        once = false;
+                }
+
+                return 0;
+      }
 
       return alpha[index](rho_i);
     }

--- a/eph_beta.h
+++ b/eph_beta.h
@@ -170,16 +170,10 @@ class EPH_Beta {
 
     Float get_beta(size_t index, Float rho_i) const {
       assert(index < n_elements);
-      static bool once = true;
 
       if(rho_i > rho_cutoff){
-
-                if(once){
-                        std::cout << 'WARNING: function get_beta() in eph_beta.h: rho_i > rho_cutoff, beta set to zero\n';
-                        once = false;
-                }
-
-                return 0;
+        std::cout << 'WARNING: function get_beta() in eph_beta.h: rho_i > rho_cutoff, beta set to zero\n';
+        return 0;
       }
 
 
@@ -191,13 +185,8 @@ class EPH_Beta {
       static bool once = true;
 
       if(rho_i > rho_cutoff){
-
-                if(once){
-                        std::cout << 'WARNING: function get_alpha() in eph_beta.h: rho_i > rho_cutoff, alpha set to zero\n';
-                        once = false;
-                }
-
-                return 0;
+        std::cout << 'WARNING: function get_alpha() in eph_beta.h: rho_i > rho_cutoff, alpha set to zero\n';
+        return 0;
       }
 
       return alpha[index](rho_i);


### PR DESCRIPTION
The function eph_beta() returns now zero when the local electron density is higher than the cutoff in the .beta file. 
This way, there is no need to append zeros to the end of .beta file. 

Additionally, the program gives a warning message if this happens during the run. 